### PR TITLE
For radio, V3 does not work

### DIFF
--- a/resources/lib/rtsplayradio.py
+++ b/resources/lib/rtsplayradio.py
@@ -44,6 +44,7 @@ class RTSPlayRadio(srgssr.SRGSSR):
     def __init__(self):
         super(RTSPlayRadio, self).__init__(
             int(sys.argv[1]), bu='rts', addon_id=ADDON_ID)
+        self.apiv3_url = None
 
 
 def log(msg, level=xbmc.LOGDEBUG):


### PR DESCRIPTION
For radio, disable v3 api. Overrides the inconditional use of v3 api in srgssr script